### PR TITLE
[Feature, WIP] Add zoom rotate

### DIFF
--- a/iz_helpers/__init__.py
+++ b/iz_helpers/__init__.py
@@ -1,2 +1,2 @@
-from .image import shrink_and_paste_on_blank
+from .image import shrink_rotate_and_paste_on_blank
 from .video import write_video

--- a/iz_helpers/__init__.py
+++ b/iz_helpers/__init__.py
@@ -1,2 +1,2 @@
-from .image import shrink_rotate_and_paste_on_blank
+from .image import shrink_rotate_and_paste_on_blank,zoom_image
 from .video import write_video

--- a/iz_helpers/image.py
+++ b/iz_helpers/image.py
@@ -22,3 +22,28 @@ def shrink_rotate_and_paste_on_blank(current_image, mask_width, mask_height, rot
     blank_image = blank_image.rotate(rotate_angle, resample=Image.BICUBIC)
 
     return blank_image
+
+
+from PIL import Image
+
+def zoom_image(img, zoom_factor, rotate_angle):
+    # Get the original size of the image
+    width, height = img.size
+
+    # Calculate the new size of the image
+    new_width = int(width * zoom_factor)
+    new_height = int(height * zoom_factor)
+
+    img = img.convert("RGBA")
+    img = img.rotate(rotate_angle)
+
+    # Resize the image using the new size
+    zoomed_image = img.resize((new_width, new_height))
+
+    # Create a new image with the same dimensions as the original image
+    output_image = Image.new("RGBA", (width, height), (1,0,0,0))
+
+    # Paste the zoomed image onto the output image
+    output_image.paste(zoomed_image, (int((width - new_width) / 2), int((height - new_height) / 2)))
+
+    return output_image

--- a/iz_helpers/image.py
+++ b/iz_helpers/image.py
@@ -1,6 +1,6 @@
 from PIL import Image
 
-def shrink_and_paste_on_blank(current_image, mask_width, mask_height):
+def shrink_rotate_and_paste_on_blank(current_image, mask_width, mask_height, rotate_angle=0):
     """
     Decreases size of current_image by mask_width pixels from each side,
     then adds a mask_width width transparent frame,
@@ -19,5 +19,6 @@ def shrink_and_paste_on_blank(current_image, mask_width, mask_height):
     prev_image = current_image.resize((new_width, new_height))
     blank_image = Image.new("RGBA", (width, height), (0, 0, 0, 1))
     blank_image.paste(prev_image, (mask_width, mask_height))
+    blank_image = blank_image.rotate(rotate_angle, resample=Image.BICUBIC)
 
     return blank_image

--- a/scripts/infinite-zoom.py
+++ b/scripts/infinite-zoom.py
@@ -287,6 +287,7 @@ def create_zoom_single(
 
         current_image.paste(prev_image, mask=prev_image)
 
+
         # interpolation steps between 2 inpainted images (=sequential zoom and crop)
         for j in range(num_interpol_frames - 1):
             interpol_image = current_image

--- a/scripts/infonite-zoom.py
+++ b/scripts/infonite-zoom.py
@@ -407,8 +407,8 @@ def on_ui_tabs():
                         info="The more it is, the longer your videos will be",
                     )
                     main_rotate_per_step = gr.Slider(
-                        minimum=-360,
-                        maximum=360,
+                        minimum=-180,
+                        maximum=180,
                         step=1,
                         value=0,
                         label="Rotation (degrees per step)",


### PR DESCRIPTION
This PR adds the option to rotate the image before inpainting, making for a nice combined zoom & rotate effect.

See an example here: 

https://user-images.githubusercontent.com/19559859/232900543-22a3153d-4a08-4355-82e1-03a933aecedc.mp4

One obvious problem are the black borders in the generated video. Although this can be fixed by cropping the video a bit afterward, that is not an ideal solution.

Thus, this is marked as a WIP for now. I will see what I can do, but I don't think there is a straight-forward solution. With a little bit of rewriting of the create_zoom_single function, it should be doable though: first generate all the outpainted images, then create all the interpolated frames only at the end... 

You can merge it already, or leave it as-is for now until I do more progress. No preference from my side.