### PR TITLE
Fix typo in static variables

### DIFF
--- a/iz_helpers/static_variables.py
+++ b/iz_helpers/static_variables.py
@@ -32,7 +32,7 @@ invalid_prompt = {
         "data": [[0, "Your prompt-json is invalid, please check Settings"]],
     },
     "negPrompt": "Invalid prompt-json",
-    "prePromp": "Invalid prompt",
+    "prePrompt": "Invalid prompt",
     "postPrompt": "Invalid prompt",
 }
 


### PR DESCRIPTION
Hotfix due to broken interface 

static_variables.py key value was spelled incorrectly.