### PR TITLE
Fix two text errors

### DIFF
--- a/javascript/infinite-zoom-hints.js
+++ b/javascript/infinite-zoom-hints.js
@@ -2,7 +2,7 @@
 
 infzoom_titles = {
     "Batch Count":"How many separate videos to create",
-    "Total video length [s]":"For each seconds frame (FPS) will be generated. Define prompts at which time they should start wihtin this duration.",
+    "Total video length [s]":"For each seconds frame (FPS) will be generated. Define prompts at which time they should start within this duration.",
     "Common Prompt Prefix":"Prompt inserted before each step",
     "Common Prompt Suffix":"Prompt inserted after each step",
     "Negative Prompt":"What your model shall avoid",
@@ -12,7 +12,7 @@ infzoom_titles = {
     "Custom initial image":"An image at the end resp. begin of your movie, depending or ZoomIn or Out",
     "Custom exit image":"An image at the end resp. begin of your movie, depending or ZoomIn or Out",
     "Zoom Speed":"Varies additional frames per second",
-    "Start at second [0,1,...]": "At which time the prompt has to be occure. We need at least one prompt starting at time 0",
+    "Start at second [0,1,...]": "At which time the prompt has to occur. We need at least one prompt starting at time 0",
 	"Generate video": "Start rendering. If it´s disabled the prompt table is invalid, check we have a start prompt at time 0"
 }
 


### PR DESCRIPTION
While working on the localisation translation, I noticed that two hints could never be selected. Upon checking the original file, I found that it was due to some spelling and grammatical errors, so I just corrected them.